### PR TITLE
Prefill token, update usage guide, fix connection init, and style chat console

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ This repository contains a minimal HTML/JavaScript demo for Agora Chat.
 ## Usage
 
 1. Open `index.html` in a web browser.
-2. Enter the user token.
+2. The token field is pre-filled with a demo value. Replace it if needed.
 3. (Optional) Change the user ID or app key.
-4. Click **Login** to connect.
+4. Click **Login** to connect to `msync-api-61.chat.agora.io`.
 5. Use **Get Friend List** to fetch friends.
 6. Send messages and view incoming messages in the list.
+
+> Note: The demo disables `XMLHttpRequest` credentials to avoid CORS issues when opened from the local file system.
+> The connection explicitly enables HTTPS and bypasses the SDK's DNS by providing the `msync-api-61` URLs directly.

--- a/app.js
+++ b/app.js
@@ -1,4 +1,17 @@
 let conn;
+const AC = window.WebIM || window.AgoraChat || window.agoraChat;
+
+// Ensure cross-origin requests avoid sending credentials so that
+// the msync-api-61.chat.agora.io endpoint, which responds with
+// `Access-Control-Allow-Origin: *`, will pass CORS checks when this
+// page is opened from the local file system.
+if (window.XMLHttpRequest) {
+  const origOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function (...args) {
+    origOpen.apply(this, args);
+    this.withCredentials = false;
+  };
+}
 
 function log(text) {
   const msgList = document.getElementById("messages");
@@ -22,9 +35,13 @@ window.addEventListener("load", () => {
       return;
     }
 
-    conn = new AgoraChat.connection({
+    conn = new AC.connection({
       appKey,
       autoReconnect: true,
+      https: true,
+      isHttpDNS: false,
+      url: "msync-api-61.chat.agora.io/ws",
+      apiUrl: "a61.chat.agora.io",
     });
 
     conn.addEventHandler("demo", {
@@ -60,6 +77,9 @@ window.addEventListener("load", () => {
         if (r.subscription === "both") {
           const li = document.createElement("li");
           li.textContent = r.name;
+          li.addEventListener("click", () => {
+            document.getElementById("toUser").value = r.name;
+          });
           list.appendChild(li);
         }
       });
@@ -81,7 +101,7 @@ window.addEventListener("load", () => {
       return;
     }
 
-    const msg = AgoraChat.message.create({
+    const msg = AC.message.create({
       type: "txt",
       chatType: "singleChat",
       to: toUser,

--- a/index.html
+++ b/index.html
@@ -5,28 +5,41 @@
   <title>Agora Chat Console</title>
   <script src="./node_modules/agora-chat/Agora-chat.js"></script>
   <script defer src="app.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; }
+    #loginForm { padding: 10px; border-bottom: 1px solid #ccc; }
+    #chatContainer { display: flex; height: 80vh; }
+    #friendsPanel { width: 200px; border-right: 1px solid #ccc; overflow-y: auto; }
+    #friends { list-style: none; padding: 0; margin: 0; }
+    #friends li { padding: 5px; cursor: pointer; }
+    #friends li:hover { background: #eee; }
+    #chatPanel { flex: 1; display: flex; flex-direction: column; }
+    #messages { flex: 1; list-style: none; padding: 10px; margin: 0; overflow-y: auto; }
+    #messages li { margin: 5px 0; }
+    #inputPanel { display: flex; padding: 10px; border-top: 1px solid #ccc; }
+    #inputPanel input { flex: 1; margin-right: 5px; }
+  </style>
 </head>
 <body>
-  <h1>Agora Chat Demo</h1>
-  <div>
-    <label>App Key: <input id="appKey" value="611394174#1598470"></label><br>
-    <label>User ID: <input id="userId" value="make02"></label><br>
-    <label>Token: <input id="token" type="text"></label>
+  <div id="loginForm">
+    <label>App Key: <input id="appKey" value="611394174#1598470"></label>
+    <label>User ID: <input id="userId" value="make02"></label>
+    <label>Token: <input id="token" type="text" value="007eJxTYAiSe8Mrwe/MGH5m5qnlUp85H/Aa/omPNc4T3DK/oj9P94kCQ1KSeZJhSkqiZUqSgYmBeapFqomFgUlyioGxhaGlkbkp060jGQ2BjAzFH0KYGBlYGRiBEMRXYTBKTU0yM7M00LVISjbTNTRMM9C1NE5K0zVIMjVJtEwzSTUxSwUAjvAlsA=="></label>
     <button id="loginBtn">Login</button>
-  </div>
-  <div>
     <button id="getFriendsBtn">Get Friend List</button>
-    <ul id="friends"></ul>
   </div>
-  <div>
-    <h2>Send Message</h2>
-    <label>To: <input id="toUser"></label><br>
-    <label>Message: <input id="msgText"></label><br>
-    <button id="sendBtn">Send</button>
-  </div>
-  <div>
-    <h2>Messages</h2>
-    <ul id="messages"></ul>
+  <div id="chatContainer">
+    <div id="friendsPanel">
+      <ul id="friends"></ul>
+    </div>
+    <div id="chatPanel">
+      <ul id="messages"></ul>
+      <div id="inputPanel">
+        <input id="toUser" placeholder="To">
+        <input id="msgText" placeholder="Type a message">
+        <button id="sendBtn">Send</button>
+      </div>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Pre-fill token field with provided demo token for easier login
- Clarify README instructions about default token usage
- Use WebIM global fallback to construct Agora Chat connection correctly
- Disable credentials on `XMLHttpRequest` and point SDK to msync server to avoid CORS errors
- Style chat console with sidebar and message pane; allow clicking friend to populate recipient
- Enforce HTTPS and disable SDK DNS so the msync server is used directly

## Testing
- `node -e "new Function(require('fs').readFileSync('app.js','utf8')); console.log('app.js syntax ok');"`
- `node -e "const AC=require('./node_modules/agora-chat/Agora-chat.js'); console.log('sdk loaded');"` *(fails: output exceeds capture limit due to library format)*

------
https://chatgpt.com/codex/tasks/task_e_68c51a273134832cbc572aa5dbf8f24c