### PR TITLE
Add Signal protocol web/Java demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Maven build output
+java-client/target/
+
+# IDE metadata
+.idea/
+*.iml
+
+# Node modules (if future tooling is added)
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Signal 协议双端示例
+
+本示例演示如何使用 [signalapp/libsignal](https://github.com/signalapp/libsignal) 在浏览器和 Java 程序之间模拟两个客户端的端到端加密通信流程。示例包含：
+
+- `index.html`：基于 `libsignal-protocol.js` 的 Web 页面，负责生成身份密钥、PreKey Bundle，并在浏览器端完成加密与解密。
+- `java-client`：使用 Maven 构建的 Java HTTP 服务端，基于 `signal-protocol-java` 实现密钥管理、消息加解密以及向浏览器提供 REST 接口。
+
+## 功能概览
+
+1. 浏览器端生成身份密钥、PreKey Bundle，并通过 `/web/prekey` 接口注册到 Java 端。
+2. 浏览器端拉取 Java 端的 PreKey Bundle（`/java/prekey`）并与之建立会话。
+3. 浏览器端输入的消息通过 Signal 协议加密后发送到 Java 端（`/messages/from-web`），Java 端解密并返回明文以便演示。
+4. Java 端可根据 `/messages/java/send` 请求加密任意明文并存入待取队列，浏览器端通过 `/messages/to-web` 拉取并解密。
+
+## 快速开始
+
+### 1. 启动 Java 服务
+
+```bash
+# 进入仓库根目录
+mvn -pl java-client exec:java
+```
+
+该命令会启动一个监听 `http://localhost:8080` 的 HTTP 服务，并同时提供静态页面 `index.html`。终端会显示可用接口列表。
+
+> 首次执行时 Maven 会从中央仓库下载依赖，请确保网络可访问 Maven Central。
+
+### 2. 打开 Web 页面
+
+在浏览器访问 [http://localhost:8080/](http://localhost:8080/) 即可加载演示页面。页面加载后会自动：
+
+1. 生成浏览器端的身份密钥和 PreKey；
+2. 将 PreKey Bundle 发送到 Java 服务；
+3. 获取 Java 的 PreKey Bundle 并建立 Signal 会话。
+
+如果需要重新初始化密钥，可点击“重新初始化密钥”按钮。
+
+### 3. 交互流程
+
+- **Web → Java**：在“Web → Java”区域输入文本，点击“加密并发送到 Java”。浏览器会使用 Signal 会话加密消息，通过 `/messages/from-web` 提交。Java 端解密后返回明文，页面日志会显示结果。
+- **Java → Web**：在“Java → Web”区域输入文本，点击“让 Java 客户端加密该消息”。服务端会使用现有会话加密并存入队列。随后点击“获取等待 Web 解密的密文”拉取密文并在浏览器端解密，结果显示在日志和下方区域。
+
+## 目录结构
+
+```
+├── index.html            # Web 端演示页面
+├── java-client           # Java 示例项目
+│   ├── pom.xml
+│   └── src/main/java/com/example/signal
+│       ├── MessageEnvelope.java
+│       ├── PreKeyBundleDTO.java
+│       ├── SignalClient.java
+│       └── SignalServer.java
+└── README.md
+```
+
+## 注意事项
+
+- 示例仅用于演示 Signal 协议的会话建立及消息收发流程，未考虑长期密钥存储、安全持久化等生产环境需求。
+- Web 端脚本直接依赖公共 CDN 上的 `libsignal-protocol.js`，如需离线运行，请将对应脚本下载到本地并修改引用路径。
+- Java 服务为简化演示，使用内存存储会话与消息队列，重启服务会导致所有状态丢失。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <title>Signal 协议端到端加密演示</title>
+  <style>
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      margin: 2rem auto;
+      max-width: 900px;
+      line-height: 1.6;
+      color: #1f2933;
+      background-color: #f7fafc;
+    }
+
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+    }
+
+    section {
+      background: #ffffff;
+      border-radius: 8px;
+      box-shadow: 0 8px 30px rgba(15, 23, 42, 0.12);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    label {
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    textarea, input[type="text"] {
+      width: 100%;
+      padding: 0.75rem;
+      border: 1px solid #cbd5e0;
+      border-radius: 6px;
+      font-size: 1rem;
+      font-family: inherit;
+      box-sizing: border-box;
+      background-color: #fdfdfd;
+    }
+
+    button {
+      margin-top: 0.75rem;
+      padding: 0.65rem 1.25rem;
+      background-color: #2563eb;
+      border: none;
+      border-radius: 6px;
+      color: white;
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: background 0.2s ease-in-out;
+    }
+
+    button:disabled {
+      background-color: #94a3b8;
+      cursor: wait;
+    }
+
+    button:hover:not(:disabled) {
+      background-color: #1d4ed8;
+    }
+
+    #log {
+      height: 240px;
+      overflow-y: auto;
+      background: #0f172a;
+      color: #f8fafc;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+      font-size: 0.9rem;
+      padding: 1rem;
+      border-radius: 6px;
+      white-space: pre-wrap;
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/libsignal-protocol@2.4.0/dist/libsignal-protocol.min.js"></script>
+</head>
+<body>
+  <h1>Signal 协议端到端加密演示</h1>
+  <p>此页面和 Java 后端示例程序一起，模拟两个客户端之间通过 Signal 协议进行端到端加密通信。</p>
+
+  <section>
+    <h2>初始化状态</h2>
+    <p id="status">正在启动……</p>
+    <button id="initButton">重新初始化密钥</button>
+  </section>
+
+  <section>
+    <h2>Web → Java</h2>
+    <label for="webMessage">要发送给 Java 客户端的消息</label>
+    <textarea id="webMessage" rows="3" placeholder="输入文本后点击发送"></textarea>
+    <button id="sendToJava">加密并发送到 Java</button>
+  </section>
+
+  <section>
+    <h2>Java → Web</h2>
+    <label for="javaMessage">由 Java 客户端发送的消息内容</label>
+    <input id="javaMessage" type="text" placeholder="例如：Hello from Java" />
+    <button id="askJavaToSend">让 Java 客户端加密该消息</button>
+    <button id="fetchFromJava">获取等待 Web 解密的密文</button>
+    <div id="javaMessages"></div>
+  </section>
+
+  <section>
+    <h2>日志</h2>
+    <div id="log"></div>
+  </section>
+
+  <script>
+    function SignalProtocolStore() {
+      this.store = {};
+    }
+
+    SignalProtocolStore.prototype = {
+      getIdentityKeyPair() {
+        return this.get('identityKey');
+      },
+      getLocalRegistrationId() {
+        return this.get('registrationId');
+      },
+      put(key, value) {
+        this.store[key] = value;
+      },
+      get(key, defaultValue) {
+        if (Object.prototype.hasOwnProperty.call(this.store, key)) {
+          return this.store[key];
+        }
+        return defaultValue;
+      },
+      remove(key) {
+        delete this.store[key];
+      },
+      reset() {
+        this.store = {};
+      },
+      isTrustedIdentity() {
+        return true;
+      },
+      saveIdentity(identifier, identityKey) {
+        const existing = this.get('identityKey' + identifier);
+        this.put('identityKey' + identifier, identityKey);
+        if (existing) {
+          return arrayBufferToBase64(existing) === arrayBufferToBase64(identityKey);
+        }
+        return true;
+      },
+      loadIdentityKey(identifier) {
+        return this.get('identityKey' + identifier);
+      },
+      loadPreKey(keyId) {
+        return this.get('preKey' + keyId);
+      },
+      storePreKey(keyId, keyPair) {
+        this.put('preKey' + keyId, keyPair);
+      },
+      removePreKey(keyId) {
+        this.remove('preKey' + keyId);
+      },
+      loadSignedPreKey(keyId) {
+        return this.get('signedPreKey' + keyId);
+      },
+      storeSignedPreKey(keyId, keyPair) {
+        this.put('signedPreKey' + keyId, keyPair);
+      },
+      removeSignedPreKey(keyId) {
+        this.remove('signedPreKey' + keyId);
+      },
+      loadSession(identifier) {
+        return this.get('session' + identifier);
+      },
+      storeSession(identifier, record) {
+        this.put('session' + identifier, record);
+      },
+      removeSession(identifier) {
+        this.remove('session' + identifier);
+      },
+      removeAllSessions(identifier) {
+        Object.keys(this.store)
+          .filter((key) => key.startsWith('session' + identifier))
+          .forEach((key) => delete this.store[key]);
+      },
+      getSubDeviceSessions() {
+        return [];
+      }
+    };
+
+    const Signal = window.libsignal;
+    const store = new SignalProtocolStore();
+    const JAVA_ADDRESS = new Signal.SignalProtocolAddress('java', 1);
+    const STATUS = document.getElementById('status');
+    const LOG = document.getElementById('log');
+    const initButton = document.getElementById('initButton');
+    const sendButton = document.getElementById('sendToJava');
+    const askJavaButton = document.getElementById('askJavaToSend');
+    const fetchButton = document.getElementById('fetchFromJava');
+
+    let identityKeyPair;
+    let registrationId;
+    let preKeyId = 1;
+    let signedPreKeyId = 1;
+
+    initButton.addEventListener('click', () => initialise(true));
+    sendButton.addEventListener('click', sendToJava);
+    askJavaButton.addEventListener('click', sendJavaMessageRequest);
+    fetchButton.addEventListener('click', fetchMessagesFromJava);
+
+    disableControls();
+    initialise(false);
+
+    async function initialise(reset) {
+      try {
+        disableControls();
+        if (reset) {
+          store.reset();
+          preKeyId = 1;
+          signedPreKeyId = 1;
+          log('重置本地存储。');
+        }
+        STATUS.textContent = '生成身份密钥对…';
+        identityKeyPair = await Signal.KeyHelper.generateIdentityKeyPair();
+        registrationId = await Signal.KeyHelper.generateRegistrationId();
+        store.put('identityKey', identityKeyPair);
+        store.put('registrationId', registrationId);
+
+        STATUS.textContent = '生成 PreKey / SignedPreKey…';
+        const preKey = await Signal.KeyHelper.generatePreKey(preKeyId);
+        const signedPreKey = await Signal.KeyHelper.generateSignedPreKey(identityKeyPair, signedPreKeyId);
+        store.storePreKey(preKeyId, preKey.keyPair);
+        store.storeSignedPreKey(signedPreKeyId, signedPreKey.keyPair);
+
+        STATUS.textContent = '向 Java 注册 Web 端 PreKey Bundle…';
+        const bundle = {
+          registrationId,
+          deviceId: 1,
+          preKeyId,
+          preKeyPublic: arrayBufferToBase64(preKey.keyPair.pubKey),
+          signedPreKeyId,
+          signedPreKeyPublic: arrayBufferToBase64(signedPreKey.keyPair.pubKey),
+          signedPreKeySignature: arrayBufferToBase64(signedPreKey.signature),
+          identityKeyPublic: arrayBufferToBase64(identityKeyPair.pubKey)
+        };
+        await fetch('/web/prekey', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(bundle)
+        });
+        log('已向 Java 端提交 Web 的 PreKey Bundle。');
+
+        STATUS.textContent = '获取 Java PreKey Bundle 并建立会话…';
+        const javaBundleResponse = await fetch('/java/prekey');
+        const javaBundle = await javaBundleResponse.json();
+        const processedBundle = {
+          registrationId: javaBundle.registrationId,
+          deviceId: javaBundle.deviceId,
+          preKeyId: javaBundle.preKeyId,
+          preKeyPublic: base64ToArrayBuffer(javaBundle.preKeyPublic),
+          signedPreKeyId: javaBundle.signedPreKeyId,
+          signedPreKeyPublic: base64ToArrayBuffer(javaBundle.signedPreKeyPublic),
+          signedPreKeySignature: base64ToArrayBuffer(javaBundle.signedPreKeySignature),
+          identityKey: base64ToArrayBuffer(javaBundle.identityKeyPublic)
+        };
+        const sessionBuilder = new Signal.SessionBuilder(store, JAVA_ADDRESS);
+        await sessionBuilder.processPreKey(processedBundle);
+        log('已与 Java 客户端建立会话。');
+
+        STATUS.textContent = '完成初始化，可以开始通信。';
+        enableControls();
+      } catch (error) {
+        console.error(error);
+        log('初始化失败: ' + error.message);
+        STATUS.textContent = '初始化失败，请检查 Java 服务是否已启动。';
+        enableControls(false);
+      }
+    }
+
+    async function sendToJava() {
+      try {
+        const message = document.getElementById('webMessage').value.trim();
+        if (!message) {
+          alert('请输入要发送的内容');
+          return;
+        }
+        const cipher = new Signal.SessionCipher(store, JAVA_ADDRESS);
+        const ciphertext = await cipher.encrypt(textToArrayBuffer(message));
+        const type = ciphertext.type === 3 ? 'PREKEY' : 'SIGNAL';
+        const payload = {
+          type,
+          body: arrayBufferToBase64(ciphertext.body)
+        };
+        const response = await fetch('/messages/from-web', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await response.json();
+        log('→ Web 向 Java 发送密文，Java 解密得到: ' + data.plaintext);
+      } catch (error) {
+        console.error(error);
+        log('发送失败: ' + error.message);
+      }
+    }
+
+    async function sendJavaMessageRequest() {
+      try {
+        const message = document.getElementById('javaMessage').value.trim();
+        if (!message) {
+          alert('请输入 Java 端要发送的消息内容');
+          return;
+        }
+        const response = await fetch('/messages/java/send', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ plaintext: message })
+        });
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(text || 'Java 端发送失败');
+        }
+        const envelope = await response.json();
+        log('Java 已加密消息并存入待领取队列，类型: ' + envelope.type);
+      } catch (error) {
+        console.error(error);
+        log('请求 Java 发送消息失败: ' + error.message);
+      }
+    }
+
+    async function fetchMessagesFromJava() {
+      try {
+        const response = await fetch('/messages/to-web');
+        const envelopes = await response.json();
+        if (!envelopes.length) {
+          log('当前没有待解密的 Java → Web 消息。');
+          return;
+        }
+        const messages = [];
+        for (const envelope of envelopes) {
+          const cipher = new Signal.SessionCipher(store, JAVA_ADDRESS);
+          const body = base64ToArrayBuffer(envelope.body);
+          let plaintextBuffer;
+          if (envelope.type === 'PREKEY') {
+            plaintextBuffer = await cipher.decryptPreKeyWhisperMessage(new Uint8Array(body), 'binary');
+          } else {
+            plaintextBuffer = await cipher.decryptWhisperMessage(new Uint8Array(body), 'binary');
+          }
+          const plaintext = arrayBufferToText(plaintextBuffer);
+          messages.push(plaintext);
+          log('← Java → Web 解密得到: ' + plaintext);
+        }
+        document.getElementById('javaMessages').textContent = messages.join('\n');
+      } catch (error) {
+        console.error(error);
+        log('获取或解密 Java 消息失败: ' + error.message);
+      }
+    }
+
+    function disableControls() {
+      sendButton.disabled = true;
+      askJavaButton.disabled = true;
+      fetchButton.disabled = true;
+      initButton.disabled = true;
+    }
+
+    function enableControls(includeInit = true) {
+      sendButton.disabled = false;
+      askJavaButton.disabled = false;
+      fetchButton.disabled = false;
+      if (includeInit) {
+        initButton.disabled = false;
+      }
+    }
+
+    function log(message) {
+      const timestamp = new Date().toLocaleTimeString();
+      LOG.textContent += `[${timestamp}] ${message}\n`;
+      LOG.scrollTop = LOG.scrollHeight;
+    }
+
+    function textToArrayBuffer(text) {
+      return new TextEncoder().encode(text).buffer;
+    }
+
+    function arrayBufferToText(buffer) {
+      return new TextDecoder().decode(buffer);
+    }
+
+    function arrayBufferToBase64(buffer) {
+      const bytes = buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+      let binary = '';
+      for (let i = 0; i < bytes.byteLength; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      return btoa(binary);
+    }
+
+    function base64ToArrayBuffer(base64) {
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      return bytes.buffer;
+    }
+  </script>
+</body>
+</html>

--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>java-client</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.whispersystems</groupId>
+            <artifactId>signal-protocol-java</artifactId>
+            <version>2.8.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.example.signal.SignalServer</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java-client/src/main/java/com/example/signal/MessageEnvelope.java
+++ b/java-client/src/main/java/com/example/signal/MessageEnvelope.java
@@ -1,0 +1,39 @@
+package com.example.signal;
+
+import org.whispersystems.libsignal.protocol.CiphertextMessage;
+
+import java.util.Base64;
+
+/**
+ * Wrapper for encrypted messages exchanged between the simulated clients.
+ */
+public class MessageEnvelope {
+    public static final String TYPE_PREKEY = "PREKEY";
+    public static final String TYPE_SIGNAL = "SIGNAL";
+
+    private String type;
+    private String body;
+
+    public MessageEnvelope() {
+        // For JSON deserialisation
+    }
+
+    public MessageEnvelope(String type, String body) {
+        this.type = type;
+        this.body = body;
+    }
+
+    public static MessageEnvelope fromCiphertext(CiphertextMessage message) {
+        String type = message.getType() == CiphertextMessage.PREKEY_TYPE ? TYPE_PREKEY : TYPE_SIGNAL;
+        String body = Base64.getEncoder().encodeToString(message.serialize());
+        return new MessageEnvelope(type, body);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getBody() {
+        return body;
+    }
+}

--- a/java-client/src/main/java/com/example/signal/PreKeyBundleDTO.java
+++ b/java-client/src/main/java/com/example/signal/PreKeyBundleDTO.java
@@ -1,0 +1,109 @@
+package com.example.signal;
+
+import org.whispersystems.libsignal.IdentityKey;
+import org.whispersystems.libsignal.IdentityKeyPair;
+import org.whispersystems.libsignal.InvalidKeyException;
+import org.whispersystems.libsignal.ecc.Curve;
+import org.whispersystems.libsignal.ecc.ECKeyPair;
+import org.whispersystems.libsignal.ecc.ECPublicKey;
+import org.whispersystems.libsignal.state.PreKeyBundle;
+import org.whispersystems.libsignal.state.PreKeyRecord;
+import org.whispersystems.libsignal.state.SignedPreKeyRecord;
+
+import java.util.Base64;
+
+/**
+ * DTO used to serialize and deserialize pre-key bundles between clients.
+ */
+public class PreKeyBundleDTO {
+    private int registrationId;
+    private int deviceId;
+    private int preKeyId;
+    private String preKeyPublic;
+    private int signedPreKeyId;
+    private String signedPreKeyPublic;
+    private String signedPreKeySignature;
+    private String identityKeyPublic;
+
+    public PreKeyBundleDTO() {
+        // For JSON deserialisation
+    }
+
+    public PreKeyBundleDTO(int registrationId, int deviceId, int preKeyId, String preKeyPublic,
+                           int signedPreKeyId, String signedPreKeyPublic, String signedPreKeySignature,
+                           String identityKeyPublic) {
+        this.registrationId = registrationId;
+        this.deviceId = deviceId;
+        this.preKeyId = preKeyId;
+        this.preKeyPublic = preKeyPublic;
+        this.signedPreKeyId = signedPreKeyId;
+        this.signedPreKeyPublic = signedPreKeyPublic;
+        this.signedPreKeySignature = signedPreKeySignature;
+        this.identityKeyPublic = identityKeyPublic;
+    }
+
+    public static PreKeyBundleDTO from(IdentityKeyPair identityKeyPair, int registrationId, int deviceId,
+                                       PreKeyRecord preKey, SignedPreKeyRecord signedPreKey) {
+        ECKeyPair preKeyPair = preKey.getKeyPair();
+        ECKeyPair signedPreKeyPair = signedPreKey.getKeyPair();
+        return new PreKeyBundleDTO(
+                registrationId,
+                deviceId,
+                preKey.getId(),
+                Base64.getEncoder().encodeToString(preKeyPair.getPublicKey().serialize()),
+                signedPreKey.getId(),
+                Base64.getEncoder().encodeToString(signedPreKeyPair.getPublicKey().serialize()),
+                Base64.getEncoder().encodeToString(signedPreKey.getSignature()),
+                Base64.getEncoder().encodeToString(identityKeyPair.getPublicKey().serialize())
+        );
+    }
+
+    public int getRegistrationId() {
+        return registrationId;
+    }
+
+    public int getDeviceId() {
+        return deviceId;
+    }
+
+    public int getPreKeyId() {
+        return preKeyId;
+    }
+
+    public String getPreKeyPublic() {
+        return preKeyPublic;
+    }
+
+    public int getSignedPreKeyId() {
+        return signedPreKeyId;
+    }
+
+    public String getSignedPreKeyPublic() {
+        return signedPreKeyPublic;
+    }
+
+    public String getSignedPreKeySignature() {
+        return signedPreKeySignature;
+    }
+
+    public String getIdentityKeyPublic() {
+        return identityKeyPublic;
+    }
+
+    public PreKeyBundle toPreKeyBundle() throws InvalidKeyException {
+        ECPublicKey preKeyPublicKey = Curve.decodePoint(Base64.getDecoder().decode(preKeyPublic), 0);
+        ECPublicKey signedPreKeyPublicKey = Curve.decodePoint(Base64.getDecoder().decode(signedPreKeyPublic), 0);
+        IdentityKey identityKey = new IdentityKey(Base64.getDecoder().decode(identityKeyPublic), 0);
+        byte[] signature = Base64.getDecoder().decode(signedPreKeySignature);
+        return new PreKeyBundle(
+                registrationId,
+                deviceId,
+                preKeyId,
+                preKeyPublicKey,
+                signedPreKeyId,
+                signedPreKeyPublicKey,
+                signature,
+                identityKey
+        );
+    }
+}

--- a/java-client/src/main/java/com/example/signal/SignalClient.java
+++ b/java-client/src/main/java/com/example/signal/SignalClient.java
@@ -1,0 +1,106 @@
+package com.example.signal;
+
+import org.whispersystems.libsignal.IdentityKeyPair;
+import org.whispersystems.libsignal.InvalidKeyException;
+import org.whispersystems.libsignal.SignalProtocolAddress;
+import org.whispersystems.libsignal.protocol.CiphertextMessage;
+import org.whispersystems.libsignal.protocol.PreKeySignalMessage;
+import org.whispersystems.libsignal.protocol.SignalMessage;
+import org.whispersystems.libsignal.ratchet.SessionBuilder;
+import org.whispersystems.libsignal.ratchet.SessionCipher;
+import org.whispersystems.libsignal.state.InMemorySignalProtocolStore;
+import org.whispersystems.libsignal.state.PreKeyRecord;
+import org.whispersystems.libsignal.state.SignedPreKeyRecord;
+import org.whispersystems.libsignal.util.KeyHelper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Simple wrapper around libsignal state needed for this sample.
+ */
+public class SignalClient {
+    private final String name;
+    private final SignalProtocolAddress address;
+    private final IdentityKeyPair identityKeyPair;
+    private final int registrationId;
+    private final InMemorySignalProtocolStore store;
+    private final AtomicInteger preKeyIdCounter = new AtomicInteger(1);
+    private final AtomicInteger signedPreKeyIdCounter = new AtomicInteger(1);
+
+    private PreKeyRecord currentPreKey;
+    private SignedPreKeyRecord currentSignedPreKey;
+
+    public SignalClient(String name) {
+        try {
+            this.name = name;
+            this.address = new SignalProtocolAddress(name, 1);
+            this.identityKeyPair = KeyHelper.generateIdentityKeyPair();
+            this.registrationId = KeyHelper.generateRegistrationId(false);
+            this.store = new InMemorySignalProtocolStore(identityKeyPair, registrationId);
+            refreshPreKeys();
+        } catch (InvalidKeyException e) {
+            throw new IllegalStateException("Unable to initialise Signal client", e);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public SignalProtocolAddress getAddress() {
+        return address;
+    }
+
+    public PreKeyBundleDTO generatePreKeyBundle() {
+        try {
+            refreshPreKeys();
+            return PreKeyBundleDTO.from(identityKeyPair, registrationId, address.getDeviceId(), currentPreKey, currentSignedPreKey);
+        } catch (InvalidKeyException e) {
+            throw new IllegalStateException("Failed to create pre-key bundle", e);
+        }
+    }
+
+    public void processPreKeyBundle(String remoteName, PreKeyBundleDTO bundleDTO) {
+        try {
+            SessionBuilder sessionBuilder = new SessionBuilder(store, new SignalProtocolAddress(remoteName, 1));
+            sessionBuilder.process(bundleDTO.toPreKeyBundle());
+        } catch (InvalidKeyException e) {
+            throw new IllegalStateException("Invalid pre-key bundle received", e);
+        }
+    }
+
+    public MessageEnvelope encrypt(String remoteName, String plaintext) {
+        try {
+            SessionCipher cipher = new SessionCipher(store, new SignalProtocolAddress(remoteName, 1));
+            CiphertextMessage message = cipher.encrypt(plaintext.getBytes(StandardCharsets.UTF_8));
+            return MessageEnvelope.fromCiphertext(message);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to encrypt message", e);
+        }
+    }
+
+    public String decrypt(String remoteName, MessageEnvelope envelope) {
+        try {
+            SessionCipher cipher = new SessionCipher(store, new SignalProtocolAddress(remoteName, 1));
+            byte[] body = Base64.getDecoder().decode(envelope.getBody());
+            byte[] plaintext;
+            if (MessageEnvelope.TYPE_PREKEY.equals(envelope.getType())) {
+                plaintext = cipher.decrypt(new PreKeySignalMessage(body));
+            } else {
+                plaintext = cipher.decrypt(new SignalMessage(body));
+            }
+            return new String(plaintext, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to decrypt message", e);
+        }
+    }
+
+    private void refreshPreKeys() throws InvalidKeyException {
+        this.currentPreKey = KeyHelper.generatePreKey(preKeyIdCounter.getAndIncrement());
+        this.currentSignedPreKey = KeyHelper.generateSignedPreKey(identityKeyPair, signedPreKeyIdCounter.getAndIncrement());
+        store.storePreKey(currentPreKey.getId(), currentPreKey);
+        store.storeSignedPreKey(currentSignedPreKey.getId(), currentSignedPreKey);
+    }
+}

--- a/java-client/src/main/java/com/example/signal/SignalServer.java
+++ b/java-client/src/main/java/com/example/signal/SignalServer.java
@@ -1,0 +1,199 @@
+package com.example.signal;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+
+/**
+ * Small HTTP server that exposes endpoints for the browser demo to interact with the Java Signal client.
+ */
+public class SignalServer {
+    private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+    private final SignalClient javaClient = new SignalClient("java");
+    private final List<MessageEnvelope> pendingForWeb = new CopyOnWriteArrayList<>();
+    private final Path webRoot = determineWebRoot();
+
+    private volatile PreKeyBundleDTO webPreKeyBundle;
+
+    public static void main(String[] args) throws IOException {
+        SignalServer server = new SignalServer();
+        server.start(8080);
+        System.out.println("Signal demo server started on http://localhost:8080");
+        System.out.println("Open http://localhost:8080/ in a browser to load the web demo.");
+        System.out.println("Available API endpoints:");
+        System.out.println("GET  /java/prekey        -> Java client's pre-key bundle");
+        System.out.println("POST /web/prekey         -> Submit web client's pre-key bundle");
+        System.out.println("POST /messages/from-web  -> Encrypted message destined for Java");
+        System.out.println("POST /messages/java/send -> Ask Java client to encrypt a message for the web client");
+        System.out.println("GET  /messages/to-web    -> Retrieve encrypted messages waiting for the web client");
+    }
+
+    public void start(int port) throws IOException {
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+        httpServer.createContext("/", new StaticFileHandler());
+        httpServer.createContext("/java/prekey", new JavaPreKeyHandler());
+        httpServer.createContext("/web/prekey", new WebPreKeyHandler());
+        httpServer.createContext("/messages/from-web", new WebMessageHandler());
+        httpServer.createContext("/messages/java/send", new JavaSendHandler());
+        httpServer.createContext("/messages/to-web", new WebQueueHandler());
+        httpServer.setExecutor(Executors.newFixedThreadPool(4));
+        httpServer.start();
+    }
+
+    private class JavaPreKeyHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                sendText(exchange, 405, "Method Not Allowed");
+                return;
+            }
+            PreKeyBundleDTO bundle = javaClient.generatePreKeyBundle();
+            sendJson(exchange, 200, GSON.toJson(bundle));
+        }
+    }
+
+    private class WebPreKeyHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                sendText(exchange, 405, "Method Not Allowed");
+                return;
+            }
+            PreKeyBundleDTO bundle = GSON.fromJson(new InputStreamReader(exchange.getRequestBody(), StandardCharsets.UTF_8), PreKeyBundleDTO.class);
+            webPreKeyBundle = bundle;
+            javaClient.processPreKeyBundle("web", bundle);
+            sendText(exchange, 204, "");
+        }
+    }
+
+    private class WebMessageHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                sendText(exchange, 405, "Method Not Allowed");
+                return;
+            }
+            MessageEnvelope envelope = GSON.fromJson(new InputStreamReader(exchange.getRequestBody(), StandardCharsets.UTF_8), MessageEnvelope.class);
+            String plaintext = javaClient.decrypt("web", envelope);
+            JsonObject response = new JsonObject();
+            response.addProperty("plaintext", plaintext);
+            sendJson(exchange, 200, GSON.toJson(response));
+        }
+    }
+
+    private class JavaSendHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                sendText(exchange, 405, "Method Not Allowed");
+                return;
+            }
+            JsonObject payload = JsonParser.parseReader(new InputStreamReader(exchange.getRequestBody(), StandardCharsets.UTF_8)).getAsJsonObject();
+            String plaintext = payload.get("plaintext").getAsString();
+            if (webPreKeyBundle == null) {
+                sendText(exchange, 428, "Web pre-key bundle not yet registered");
+                return;
+            }
+            MessageEnvelope envelope = javaClient.encrypt("web", plaintext);
+            pendingForWeb.add(envelope);
+            sendJson(exchange, 200, GSON.toJson(envelope));
+        }
+    }
+
+    private class WebQueueHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                sendText(exchange, 405, "Method Not Allowed");
+                return;
+            }
+            List<MessageEnvelope> toDeliver = new ArrayList<>(pendingForWeb);
+            pendingForWeb.clear();
+            sendJson(exchange, 200, GSON.toJson(toDeliver));
+        }
+    }
+
+    private class StaticFileHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                sendText(exchange, 405, "Method Not Allowed");
+                return;
+            }
+            String requestPath = exchange.getRequestURI().getPath();
+            if (requestPath == null || "/".equals(requestPath)) {
+                requestPath = "/index.html";
+            }
+            Path file = resolveStaticPath(requestPath);
+            if (file == null || !Files.exists(file) || Files.isDirectory(file)) {
+                sendText(exchange, 404, "Not Found");
+                return;
+            }
+            byte[] data = Files.readAllBytes(file);
+            String contentType = requestPath.endsWith(".html") ? "text/html" : "text/plain";
+            exchange.getResponseHeaders().set("Content-Type", contentType + "; charset=utf-8");
+            exchange.sendResponseHeaders(200, data.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(data);
+            }
+        }
+    }
+
+    private Path resolveStaticPath(String requestPath) {
+        if (requestPath.startsWith("/")) {
+            requestPath = requestPath.substring(1);
+        }
+        Path candidate = webRoot.resolve(requestPath).normalize();
+        if (!candidate.startsWith(webRoot)) {
+            return null;
+        }
+        return candidate;
+    }
+
+    private Path determineWebRoot() {
+        Path cwd = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        if (Files.exists(cwd.resolve("index.html"))) {
+            return cwd;
+        }
+        Path parent = cwd.getParent();
+        if (parent != null && Files.exists(parent.resolve("index.html"))) {
+            return parent;
+        }
+        return cwd;
+    }
+
+    private void sendJson(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] data = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(status, data.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(data);
+        }
+    }
+
+    private void sendText(HttpExchange exchange, int status, String text) throws IOException {
+        byte[] data = text.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
+        exchange.sendResponseHeaders(status, data.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(data);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Maven-based Java Signal demo server that exposes REST endpoints and serves the web page
- implement browser client using libsignal-protocol.js to exchange encrypted messages with the Java side
- document workflow and usage instructions for the end-to-end example

## Testing
- `mvn -f java-client/pom.xml test` *(fails: network unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8900b49c832cbdfd292613a57cda