### PR TITLE
Add Signal encryption conversation demo

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -13,9 +13,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.whispersystems</groupId>
-            <artifactId>signal-protocol-java</artifactId>
-            <version>2.8.1</version>
+            <groupId>org.signal</groupId>
+            <artifactId>libsignal-client</artifactId>
+            <version>0.81.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -31,7 +31,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
-                    <mainClass>com.example.signal.SignalServer</mainClass>
+                    <mainClass>com.example.signal.SignalDemo</mainClass>
                 </configuration>
             </plugin>
         </plugins>

--- a/java-client/src/main/java/com/example/signal/SignalDemo.java
+++ b/java-client/src/main/java/com/example/signal/SignalDemo.java
@@ -1,0 +1,98 @@
+package com.example.signal;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.signal.libsignal.protocol.CiphertextMessage;
+import org.signal.libsignal.protocol.IdentityKeyPair;
+import org.signal.libsignal.protocol.SessionBuilder;
+import org.signal.libsignal.protocol.SessionCipher;
+import org.signal.libsignal.protocol.SignalProtocolAddress;
+import org.signal.libsignal.protocol.ecc.ECPublicKey;
+import org.signal.libsignal.protocol.message.PreKeySignalMessage;
+import org.signal.libsignal.protocol.message.SignalMessage;
+import org.signal.libsignal.protocol.state.InMemorySignalProtocolStore;
+import org.signal.libsignal.protocol.state.PreKeyBundle;
+import org.signal.libsignal.protocol.state.PreKeyRecord;
+import org.signal.libsignal.protocol.state.SignedPreKeyRecord;
+import org.signal.libsignal.protocol.util.KeyHelper;
+
+public class SignalDemo {
+
+    public static void main(String[] args) throws Exception {
+        ConversationParticipant alice = ConversationParticipant.create("Alice", 1);
+        ConversationParticipant bob = ConversationParticipant.create("Bob", 1);
+
+        // Share Bob's pre-key bundle with Alice so she can establish a session.
+        SessionBuilder aliceSessionBuilder = new SessionBuilder(alice.store, bob.address);
+        aliceSessionBuilder.process(bob.asPreKeyBundle());
+
+        SessionCipher aliceSessionCipher = new SessionCipher(alice.store, bob.address);
+        SessionCipher bobSessionCipher = new SessionCipher(bob.store, alice.address);
+
+        String alicePlaintext = "Hi Bob! This is Alice.";
+        CiphertextMessage firstMessage = aliceSessionCipher.encrypt(alicePlaintext.getBytes(StandardCharsets.UTF_8));
+        System.out.println("Alice encrypted: " + toHex(firstMessage.serialize()));
+
+        PreKeySignalMessage incomingPreKeyMessage = new PreKeySignalMessage(firstMessage.serialize());
+        byte[] decryptedByBob = bobSessionCipher.decrypt(incomingPreKeyMessage);
+        System.out.println("Bob decrypted: " + new String(decryptedByBob, StandardCharsets.UTF_8));
+
+        String bobPlaintext = "Nice to hear from you, Alice!";
+        CiphertextMessage secondMessage = bobSessionCipher.encrypt(bobPlaintext.getBytes(StandardCharsets.UTF_8));
+        System.out.println("Bob encrypted: " + toHex(secondMessage.serialize()));
+
+        SignalMessage incomingSignalMessage = new SignalMessage(secondMessage.serialize());
+        byte[] decryptedByAlice = aliceSessionCipher.decrypt(incomingSignalMessage);
+        System.out.println("Alice decrypted: " + new String(decryptedByAlice, StandardCharsets.UTF_8));
+    }
+
+    private static String toHex(byte[] data) {
+        StringBuilder sb = new StringBuilder(data.length * 2);
+        for (byte b : data) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private static class ConversationParticipant {
+        private final SignalProtocolAddress address;
+        private final InMemorySignalProtocolStore store;
+        private final PreKeyRecord preKey;
+        private final SignedPreKeyRecord signedPreKey;
+
+        private ConversationParticipant(String name, int deviceId, IdentityKeyPair identityKeyPair,
+                int registrationId, PreKeyRecord preKey, SignedPreKeyRecord signedPreKey) {
+            this.address = new SignalProtocolAddress(name, deviceId);
+            this.store = new InMemorySignalProtocolStore(identityKeyPair, registrationId);
+            this.preKey = preKey;
+            this.signedPreKey = signedPreKey;
+
+            this.store.storePreKey(preKey.getId(), preKey);
+            this.store.storeSignedPreKey(signedPreKey.getId(), signedPreKey);
+        }
+
+        private static ConversationParticipant create(String name, int deviceId) throws Exception {
+            IdentityKeyPair identityKeyPair = KeyHelper.generateIdentityKeyPair();
+            int registrationId = KeyHelper.generateRegistrationId(false);
+            List<PreKeyRecord> preKeys = KeyHelper.generatePreKeys(1, 1);
+            PreKeyRecord preKey = preKeys.get(0);
+            SignedPreKeyRecord signedPreKey = KeyHelper.generateSignedPreKey(identityKeyPair, 1);
+            return new ConversationParticipant(name, deviceId, identityKeyPair, registrationId, preKey, signedPreKey);
+        }
+
+        private PreKeyBundle asPreKeyBundle() {
+            ECPublicKey preKeyPublic = preKey.getKeyPair().getPublicKey();
+            ECPublicKey signedPreKeyPublic = signedPreKey.getKeyPair().getPublicKey();
+            return new PreKeyBundle(
+                    store.getLocalRegistrationId(),
+                    address.getDeviceId(),
+                    preKey.getId(),
+                    preKeyPublic,
+                    signedPreKey.getId(),
+                    signedPreKeyPublic,
+                    signedPreKey.getSignature(),
+                    store.getIdentityKeyPair().getPublicKey());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the `org.signal:libsignal-client` dependency and point the exec plugin to `SignalDemo`
- implement a self-contained `SignalDemo` main class that walks through encrypted messaging between Alice and Bob using Signal sessions

## Testing
- `mvn -f java-client/pom.xml -DskipTests package` *(fails: Maven cannot download plugins because network access is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d220584028832c814b48f934c68a5e